### PR TITLE
fix aliyun exporter

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,17 +1,31 @@
 package main
 
 import (
-	"log"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cdn"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cms"
+	"log"
 )
 
-func newCdnClient() *cms.Client {
-	cdnClient, err := cms.NewClientWithAccessKey(
+func CmsClient() *cms.Client {
+	cmsClient, err := cms.NewClientWithAccessKey(
 		config.regionId,
 		config.accessKeyId,
 		config.accessKeySecret,
 	)
 	//log.Println("testcms")
+	if err != nil {
+		log.Fatal("client init failed",err)
+	}
+
+	return cmsClient
+}
+
+func CdnClient () *cdn.Client {
+	cdnClient, err := cdn.NewClientWithAccessKey(
+		config.regionId,
+		config.accessKeyId,
+		config.accessKeySecret,
+	)
 	if err != nil {
 		log.Fatal("client init failed",err)
 	}

--- a/collector/acs_cdn.go
+++ b/collector/acs_cdn.go
@@ -17,19 +17,24 @@ func NewCdnExporter(c *cms.Client) *CdnExporter {
 	}
 }
 
-func (db *CdnExporter) RetrievehitRate() []datapoint {
+type statusPoint struct {
+	datapoint
+	Status  string  `json:"status"`
+}
+
+func (db *CdnExporter) RetrieveHitRate() []datapoint {
 	return retrieve("hitRate", db.project)
 }
 
-func (db *CdnExporter) RetrieveoriBps() []datapoint {
+func (db *CdnExporter) RetrieveOriBps() []datapoint {
 	return retrieve("ori_bps", db.project)
 }
 
-func (db *CdnExporter) Retrievel1Acc() []datapoint {
+func (db *CdnExporter) RetrieveL1Acc() []datapoint {
 	return retrieve("l1_acc", db.project)
 }
 
-func (db *CdnExporter) RetrieveoriAcc() []datapoint {
+func (db *CdnExporter) RetrieveOriAcc() []datapoint {
 	return retrieve("ori_acc", db.project)
 }
 
@@ -37,10 +42,44 @@ func (db *CdnExporter) RetrieveBPS() []datapoint {
 	return retrieve("BPS", db.project)
 }
 
-func (db *CdnExporter) Retrieveoricode4xxRatio() []datapoint {
-	return retrieve("ori_code_ratio_4xx", db.project)
+func (db *CdnExporter) RetrieveOriStatusRatio() []statusPoint {
+	statusMetrics := map[string]string{
+		"code1xx": "1xx",
+		"code2xx": "2xx",
+		"code3xx": "3xx",
+		"code4xx": "4xx",
+		"code_ratio_499": "499",
+		"code5xx": "5xx",
+	}
+	var response []statusPoint
+	for metric, status := range statusMetrics {
+		dataPoints := retrieve(metric, db.project)
+		for _, point := range dataPoints{
+			// code1xx、code2xx、code3xx 只有 Maximum 值
+			if metric == "code1xx" || metric == "code2xx" || metric == "code3xx" {
+				point.Average = point.Maximum
+			}
+			response = append(response, statusPoint{point, status})
+		}
+	}
+	return response
 }
 
-func (db *CdnExporter) Retrieveoricode5xxRatio() []datapoint {
-	return retrieve("ori_code_ratio_5xx", db.project)
+func (db *CdnExporter) RetrieveStatusRatio() []statusPoint {
+	backSourceStatusMetrics := map[string]string{
+		"ori_code_ratio_1xx": "1xx",
+		"ori_code_ratio_2xx": "2xx",
+		"ori_code_ratio_3xx": "3xx",
+		"ori_code_ratio_499": "499",
+		"ori_code_ratio_4xx": "4xx",
+		"ori_code_ratio_5xx": "5xx",
+	}
+	var response []statusPoint
+	for metric, status := range backSourceStatusMetrics {
+		dataPoints := retrieve(metric, db.project)
+		for _, point := range dataPoints{
+			response = append(response, statusPoint{point, status})
+		}
+	}
+	return response
 }

--- a/collector/cdn_domain.go
+++ b/collector/cdn_domain.go
@@ -1,0 +1,43 @@
+package collector
+
+import (
+	"fmt"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/cdn"
+	"log"
+	"strconv"
+)
+
+
+func GetDomains(cdnClient cdn.Client, status string) []string {
+	var domains []string
+	req := cdn.CreateDescribeUserDomainsRequest()
+	req.DomainStatus = status
+
+	response, err := cdnClient.DescribeUserDomains(req)
+	if err != nil {
+		log.Fatal("Error response from Aliyun:", err)
+	}
+	for _, res := range response.Domains.PageData{
+		domains = append(domains, res.DomainName)
+	}
+	return domains
+}
+
+func GetReqHitRate(cdnClient cdn.Client, domainName string) float64 {
+	var reqHitRateSum float64
+	req := cdn.CreateDescribeDomainReqHitRateDataRequest()
+	req.DomainName = domainName
+
+	response, err := cdnClient.DescribeDomainReqHitRateData(req)
+	if err != nil {
+		log.Fatal("Error response from Aliyun:", err)
+	}
+	// 最后一条记录数据不准确，影响平均值计算，去除后再计算
+	validResponse := response.ReqHitRateInterval.DataModule[:len(response.ReqHitRateInterval.DataModule)-1]
+	for _, reqHitRate := range validResponse{
+		value, _ :=strconv.ParseFloat(reqHitRate.Value, 64)
+		reqHitRateSum += value
+	}
+	reqHitRateAverage, _ := strconv.ParseFloat(fmt.Sprintf("%.3f", reqHitRateSum / float64(len(validResponse))), 64)
+	return reqHitRateAverage
+}

--- a/exporter/cdn_exporter.go
+++ b/exporter/cdn_exporter.go
@@ -120,7 +120,7 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 			e.backSourceBps,
 			prometheus.GaugeValue,
-			float64(point.Average / 1000000),
+			float64(point.Average / 1000 / 1000),
 			point.InstanceId,
 		)
 	}

--- a/exporter/cdn_exporter.go
+++ b/exporter/cdn_exporter.go
@@ -15,6 +15,8 @@ const (
 type CdnExporter struct {
 	client *cms.Client
 	cdnClient *cdn.Client
+	rangeTime            int64
+	delayTime            int64
 
 	fluxHitRate            *prometheus.Desc
 	hitRate                *prometheus.Desc
@@ -27,10 +29,12 @@ type CdnExporter struct {
 }
 
 //实例化
-func CdnCloudExporter(cmsClient *cms.Client, cdnClient *cdn.Client) *CdnExporter {
+func CdnCloudExporter(cmsClient *cms.Client, cdnClient *cdn.Client, rangeTime int64, delayTime int64) *CdnExporter {
 	return &CdnExporter{
 		client: cmsClient,
 		cdnClient: cdnClient,
+		rangeTime: rangeTime,
+		delayTime: delayTime,
 
 		fluxHitRate: prometheus.NewDesc(
 			prometheus.BuildFQName(cdnnamespace, "cdn", "flux_hit_rate"),
@@ -124,7 +128,7 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 	domains := collector.GetDomains(*e.cdnClient, "online")
 	//domains := []string{"vt3.doubanio.com"}
 	for _, domain := range domains {
-		reqHitRate := collector.GetReqHitRate(*e.cdnClient, domain)
+		reqHitRate := collector.GetReqHitRate(*e.cdnClient, domain, e.rangeTime, e.delayTime)
 		// 去除掉数据量少的域名
 		if reqHitRate < 10 {
 			continue

--- a/exporter/cdn_exporter.go
+++ b/exporter/cdn_exporter.go
@@ -14,13 +14,13 @@ const (
 type CdnExporter struct {
 	client *cms.Client
 
-	cdnhitRate         *prometheus.Desc
-	cdnoriBps          *prometheus.Desc
-	cdnl1Acc           *prometheus.Desc
-	cdnoriAcc          *prometheus.Desc
-	cdnBPS             *prometheus.Desc
-	cdnoricode4xxratio *prometheus.Desc
-	cdnoricode5xxratio *prometheus.Desc
+	hitRate                *prometheus.Desc
+	backSourceBps          *prometheus.Desc
+	BPS                    *prometheus.Desc
+	l1Acc                  *prometheus.Desc
+	backSourceAcc          *prometheus.Desc
+	backSourceStatusRatio  *prometheus.Desc
+	StatusRatio            *prometheus.Desc
 }
 
 //实例化
@@ -28,7 +28,7 @@ func CdnCloudExporter(c *cms.Client) *CdnExporter {
 	return &CdnExporter{
 		client: c,
 
-		cdnhitRate: prometheus.NewDesc(
+		hitRate: prometheus.NewDesc(
 			prometheus.BuildFQName(cdnnamespace, "cdn", "hit_rate"),
 			"边缘字节命中率(%)",
 			[]string{
@@ -36,24 +36,24 @@ func CdnCloudExporter(c *cms.Client) *CdnExporter {
 			},
 			nil,
 		),
-		cdnBPS: prometheus.NewDesc(
-			prometheus.BuildFQName(cdnnamespace, "cdn", "BPS"),
-			"边缘网络带宽(bit/s)",
+		BPS: prometheus.NewDesc(
+			prometheus.BuildFQName(cdnnamespace, "cdn", "bandwidth"),
+			"边缘网络带宽(Mbps)",
 			[]string{
 				"instanceId",
 			},
 			nil,
 		),
-		cdnoriBps: prometheus.NewDesc(
-			prometheus.BuildFQName(cdnnamespace, "cdn", "ori_bps"),
-			"回源网络带宽(bit/s)",
+		backSourceBps: prometheus.NewDesc(
+			prometheus.BuildFQName(cdnnamespace, "cdn", "ori_bandwidth"),
+			"回源网络带宽(Mbps)",
 			[]string{
 				"instanceId",
 			},
 			nil,
 		),
 
-		cdnl1Acc: prometheus.NewDesc(
+		l1Acc: prometheus.NewDesc(
 			prometheus.BuildFQName(cdnnamespace, "cdn", "l1_acc"),
 			"边缘累加请求数(Count)",
 			[]string{
@@ -62,7 +62,7 @@ func CdnCloudExporter(c *cms.Client) *CdnExporter {
 			nil,
 		),
 
-		cdnoriAcc: prometheus.NewDesc(
+		backSourceAcc: prometheus.NewDesc(
 			prometheus.BuildFQName(cdnnamespace, "cdn", "ori_acc"),
 			"回源累加请求数(Count)",
 			[]string{
@@ -71,20 +71,22 @@ func CdnCloudExporter(c *cms.Client) *CdnExporter {
 			nil,
 		),
 
-		cdnoricode4xxratio: prometheus.NewDesc(
-			prometheus.BuildFQName(cdnnamespace, "cdn", "ori_code_ratio_4xx"),
-			"回源状态码4XX占比(%)",
+		backSourceStatusRatio: prometheus.NewDesc(
+			prometheus.BuildFQName(cdnnamespace, "cdn", "ori_status_ratio"),
+			"回源状态码占比(%)",
 			[]string{
 				"instanceId",
+				"status",
 			},
 			nil,
 		),
 
-		cdnoricode5xxratio: prometheus.NewDesc(
-			prometheus.BuildFQName(cdnnamespace, "cdn", "ori_code_ratio_5xx"),
-			"回源状态码5XX占比(%)",
+		StatusRatio: prometheus.NewDesc(
+			prometheus.BuildFQName(cdnnamespace, "cdn", "status_ratio"),
+			"状态码占比(%)",
 			[]string{
 				"instanceId",
+				"status",
 			},
 			nil,
 		),
@@ -93,46 +95,46 @@ func CdnCloudExporter(c *cms.Client) *CdnExporter {
 
 //导出
 func (e *CdnExporter) Describe(ch chan<- *prometheus.Desc) {
-	ch <- e.cdnhitRate
-	ch <- e.cdnoriBps
-	ch <- e.cdnl1Acc
-	ch <- e.cdnoriAcc
-	ch <- e.cdnBPS
-	ch <- e.cdnoricode4xxratio
-	ch <- e.cdnoricode5xxratio
+	ch <- e.hitRate
+	ch <- e.backSourceBps
+	ch <- e.BPS
+	ch <- e.backSourceAcc
+	ch <- e.l1Acc
+	ch <- e.backSourceStatusRatio
+	ch <- e.StatusRatio
 }
 
 //收集
 func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 	cdnDashboard := collector.NewCdnExporter(e.client)
 
-	for _, point := range cdnDashboard.RetrievehitRate() {
+	for _, point := range cdnDashboard.RetrieveHitRate() {
 		ch <- prometheus.MustNewConstMetric(
-			e.cdnhitRate,
+			e.hitRate,
 			prometheus.GaugeValue,
 			float64(point.Average),
 			point.InstanceId,
 		)
 	}
-	for _, point := range cdnDashboard.RetrieveoriBps() {
+	for _, point := range cdnDashboard.RetrieveOriBps() {
 		ch <- prometheus.MustNewConstMetric(
-			e.cdnoriBps,
+			e.backSourceBps,
+			prometheus.GaugeValue,
+			float64(point.Average / 1000000),
+			point.InstanceId,
+		)
+	}
+	for _, point := range cdnDashboard.RetrieveL1Acc() {
+		ch <- prometheus.MustNewConstMetric(
+			e.l1Acc,
 			prometheus.GaugeValue,
 			float64(point.Average),
 			point.InstanceId,
 		)
 	}
-	for _, point := range cdnDashboard.Retrievel1Acc() {
+	for _, point := range cdnDashboard.RetrieveOriAcc() {
 		ch <- prometheus.MustNewConstMetric(
-			e.cdnl1Acc,
-			prometheus.GaugeValue,
-			float64(point.Average),
-			point.InstanceId,
-		)
-	}
-	for _, point := range cdnDashboard.RetrieveoriAcc() {
-		ch <- prometheus.MustNewConstMetric(
-			e.cdnoriAcc,
+			e.backSourceAcc,
 			prometheus.GaugeValue,
 			float64(point.Average),
 			point.InstanceId,
@@ -140,26 +142,28 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 	}
 	for _, point := range cdnDashboard.RetrieveBPS() {
 		ch <- prometheus.MustNewConstMetric(
-			e.cdnBPS,
+			e.BPS,
 			prometheus.GaugeValue,
-			float64(point.Average),
+			float64(point.Average / 1000000),
 			point.InstanceId,
 		)
 	}
-	for _, point := range cdnDashboard.Retrieveoricode4xxRatio() {
+	for _, point := range cdnDashboard.RetrieveOriStatusRatio() {
 		ch <- prometheus.MustNewConstMetric(
-			e.cdnoricode4xxratio,
+			e.backSourceStatusRatio,
 			prometheus.GaugeValue,
 			float64(point.Average),
 			point.InstanceId,
+			point.Status,
 		)
 	}
-	for _, point := range cdnDashboard.Retrieveoricode5xxRatio() {
+	for _, point := range cdnDashboard.RetrieveStatusRatio() {
 		ch <- prometheus.MustNewConstMetric(
-			e.cdnoricode5xxratio,
+			e.StatusRatio,
 			prometheus.GaugeValue,
 			float64(point.Average),
 			point.InstanceId,
+			point.Status,
 		)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ var config struct {
 	port            int
 	service         string
 	metricsPath     string
+	rangeTime       int64
+	delayTime       int64
 }
 
 func main() {
@@ -31,13 +33,15 @@ func main() {
 	flag.IntVar(&(config.port), "port", 9180, "服务监听端口")
 	flag.StringVar(&(config.service), "service", "acs_cdn", "输出Metrics的服务，默认为全部")
 	flag.StringVar(&(config.metricsPath), "metricsPath", "/metrics", "metrics path 路径, 默认为 /metrics ")
+	flag.Int64Var(&(config.rangeTime), "rangeTime", 3600, "时间范围, 开始时间=now-rangeTime")
+	flag.Int64Var(&(config.delayTime), "delayTime", 180, "时间偏移量, 结束时间=now-delayTime")
 	flag.Parse()
 
 	serviceArr := strings.Split(config.service, ",")
 	for _, ae := range serviceArr {
 		switch ae {
 		case "acs_cdn":
-			cdn := exporter.CdnCloudExporter(CmsClient(), CdnClient())
+			cdn := exporter.CdnCloudExporter(CmsClient(), CdnClient(), config.rangeTime, config.delayTime)
 			prometheus.MustRegister(cdn)
 		default:
 			log.Println("暂不支持该服务，请根据提示选择服务。")

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	for _, ae := range serviceArr {
 		switch ae {
 		case "acs_cdn":
-			cdn := exporter.CdnCloudExporter(newCdnClient())
+			cdn := exporter.CdnCloudExporter(CmsClient(), CdnClient())
 			prometheus.MustRegister(cdn)
 		default:
 			log.Println("暂不支持该服务，请根据提示选择服务。")


### PR DESCRIPTION
- [x] 增加状态码标签和采集的状态码数据
- [x] 调整带宽单位 - bit/s -> Mbps
- [x] 部分名称调整

采集数据问题，目前采集时只常出现vt3.doubanio.com、qnmob3.doubanio.com、pypi.doubanio.com、s.doubanio.com、   img3.doubanio.com、mr3.doubanio.com这6个域名的数据，实际控制台有8个正常运行的域名
1. 缺少的域名。未设置查询监控数据的开始、结束时间和区间，会取最近的区间数据，但未出现的域名数据比较少，调整开始和结束时间为1天时能获取到数据
2. 已停止却有数据的域名。pypi.doubanio.com 域名状态是已停止，目前阿里云客服那边还在和开发确认数据来源