### PR TITLE
add start and end time for DescribeMetricLast

### DIFF
--- a/collector/acs_cdn.go
+++ b/collector/acs_cdn.go
@@ -22,64 +22,22 @@ type statusPoint struct {
 	Status  string  `json:"status"`
 }
 
-func (db *CdnExporter) RetrieveHitRate() []datapoint {
-	return retrieve("hitRate", db.project)
+func (db *CdnExporter) RetrieveHitRate(rangeTime int64, delayTime int64) []datapoint {
+	return retrieve("hitRate", db.project, rangeTime, delayTime)
 }
 
-func (db *CdnExporter) RetrieveOriBps() []datapoint {
-	return retrieve("ori_bps", db.project)
+func (db *CdnExporter) RetrieveOriBps(rangeTime int64, delayTime int64) []datapoint {
+	return retrieve("ori_bps", db.project, rangeTime, delayTime)
 }
 
-func (db *CdnExporter) RetrieveL1Acc() []datapoint {
-	return retrieve("l1_acc", db.project)
+func (db *CdnExporter) RetrieveL1Acc(rangeTime int64, delayTime int64) []datapoint {
+	return retrieve("l1_acc", db.project, rangeTime, delayTime)
 }
 
-func (db *CdnExporter) RetrieveOriAcc() []datapoint {
-	return retrieve("ori_acc", db.project)
+func (db *CdnExporter) RetrieveOriAcc(rangeTime int64, delayTime int64) []datapoint {
+	return retrieve("ori_acc", db.project, rangeTime, delayTime)
 }
 
-func (db *CdnExporter) RetrieveBPS() []datapoint {
-	return retrieve("BPS", db.project)
-}
-
-func (db *CdnExporter) RetrieveStatusRatio() []statusPoint {
-	statusMetrics := map[string]string{
-		"code1xx": "1xx",
-		"code2xx": "2xx",
-		"code3xx": "3xx",
-		"code4xx": "4xx",
-		"code_ratio_499": "499",
-		"code5xx": "5xx",
-	}
-	var response []statusPoint
-	for metric, status := range statusMetrics {
-		dataPoints := retrieve(metric, db.project)
-		for _, point := range dataPoints{
-			// code1xx、code2xx、code3xx 只有 Maximum 值
-			if metric == "code1xx" || metric == "code2xx" || metric == "code3xx" {
-				point.Average = point.Maximum
-			}
-			response = append(response, statusPoint{point, status})
-		}
-	}
-	return response
-}
-
-func (db *CdnExporter) RetrieveOriStatusRatio() []statusPoint {
-	backSourceStatusMetrics := map[string]string{
-		"ori_code_ratio_1xx": "1xx",
-		"ori_code_ratio_2xx": "2xx",
-		"ori_code_ratio_3xx": "3xx",
-		"ori_code_ratio_499": "499",
-		"ori_code_ratio_4xx": "4xx",
-		"ori_code_ratio_5xx": "5xx",
-	}
-	var response []statusPoint
-	for metric, status := range backSourceStatusMetrics {
-		dataPoints := retrieve(metric, db.project)
-		for _, point := range dataPoints{
-			response = append(response, statusPoint{point, status})
-		}
-	}
-	return response
+func (db *CdnExporter) RetrieveBPS(rangeTime int64, delayTime int64) []datapoint {
+	return retrieve("BPS", db.project, rangeTime, delayTime)
 }

--- a/exporter/cdn_exporter.go
+++ b/exporter/cdn_exporter.go
@@ -167,7 +167,7 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 		}
 	}
 
-	for _, point := range cdnDashboard.RetrieveHitRate() {
+	for _, point := range cdnDashboard.RetrieveHitRate(e.rangeTime, e.delayTime) {
 		ch <- prometheus.MustNewConstMetric(
 			e.fluxHitRate,
 			prometheus.GaugeValue,
@@ -176,7 +176,7 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 		)
 	}
 
-	for _, point := range cdnDashboard.RetrieveOriBps() {
+	for _, point := range cdnDashboard.RetrieveOriBps(e.rangeTime, e.delayTime) {
 		ch <- prometheus.MustNewConstMetric(
 			e.backSourceBps,
 			prometheus.GaugeValue,
@@ -184,7 +184,7 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 			point.InstanceId,
 		)
 	}
-	for _, point := range cdnDashboard.RetrieveL1Acc() {
+	for _, point := range cdnDashboard.RetrieveL1Acc(e.rangeTime, e.delayTime) {
 		ch <- prometheus.MustNewConstMetric(
 			e.l1Acc,
 			prometheus.GaugeValue,
@@ -192,7 +192,7 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 			point.InstanceId,
 		)
 	}
-	for _, point := range cdnDashboard.RetrieveOriAcc() {
+	for _, point := range cdnDashboard.RetrieveOriAcc(e.rangeTime, e.delayTime) {
 		ch <- prometheus.MustNewConstMetric(
 			e.backSourceAcc,
 			prometheus.GaugeValue,
@@ -200,7 +200,7 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 			point.InstanceId,
 		)
 	}
-	for _, point := range cdnDashboard.RetrieveBPS() {
+	for _, point := range cdnDashboard.RetrieveBPS(e.rangeTime, e.delayTime) {
 		ch <- prometheus.MustNewConstMetric(
 			e.BPS,
 			prometheus.GaugeValue,


### PR DESCRIPTION
云监控接口[DescribeMetricLast](https://next.api.aliyun.com/api/Cms/2019-01-01/DescribeMetricLast?spm=api-workbench.API+Document.0.0.21281e0frRnNY2&lang=GO&sdkStyle=old&params={%22Namespace%22:%22acs_cdn%22,%22MetricName%22:%22BPS%22}&tab=DEBUG&accounttraceid=a191b527a8894d1c9815c84ba064ee4cgxbj)偶尔出现返回结果为 []，一段时间后会自动恢复（半个小时或以上）
在复现时发现加上 start and end time 会得到预期的结果，不过这个问题偶现且StartTime和EndTime都是非必须的参数，先加上看看后续是否还出现相同问题

![image](https://user-images.githubusercontent.com/51444798/198535923-50bd6026-f24b-4bad-8f61-8b4e3b7519e1.png)
