### PR TITLE
reduce rangeTime

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	flag.IntVar(&(config.port), "port", 9180, "服务监听端口")
 	flag.StringVar(&(config.service), "service", "acs_cdn", "输出Metrics的服务，默认为全部")
 	flag.StringVar(&(config.metricsPath), "metricsPath", "/metrics", "metrics path 路径, 默认为 /metrics ")
-	flag.Int64Var(&(config.rangeTime), "rangeTime", 3600, "时间范围, 开始时间=now-rangeTime")
+	flag.Int64Var(&(config.rangeTime), "rangeTime", 480, "时间范围, 开始时间=now-rangeTime")
 	flag.Int64Var(&(config.delayTime), "delayTime", 180, "时间偏移量, 结束时间=now-delayTime")
 	flag.Parse()
 


### PR DESCRIPTION
原rangeTime过大，且计算平均值，导致指标延迟，调整为480
示例：
```text
# 480 rangeTime
aliyun_cdn_ori_status_ratio{status="502"} 0.018
aliyun_cdn_ori_status_ratio{,status="503"} 26.421
aliyun_cdn_ori_status_ratio{status="504"} 0.044
aliyun_cdn_ori_status_ratio{status="5xx"} 26.483
# 3600 rangeTime
aliyun_cdn_ori_status_ratio{status="502"} 0.032
aliyun_cdn_ori_status_ratio{status="503"} 2.206
aliyun_cdn_ori_status_ratio{status="504"} 0.07
aliyun_cdn_ori_status_ratio{status="5xx"} 2.308
```
![image](https://github.com/user-attachments/assets/71031c7e-5bbf-4841-9e09-2430e892816e)

```text
# 480 rangeTime
aliyun_cdn_ori_status_ratio{status="502"} 0.04
aliyun_cdn_ori_status_ratio{status="503"} 0
aliyun_cdn_ori_status_ratio{status="504"} 0.07
aliyun_cdn_ori_status_ratio{status="5xx"} 0.11
# 3600 rangeTime
aiyun_cdn_ori_status_ratio{status="502"} 0.03
aliyun_cdn_ori_status_ratio{status="503"} 2.981
aliyun_cdn_ori_status_ratio{status="504"} 0.055
aliyun_cdn_ori_status_ratio{status="5xx"} 3.065
```
![image](https://github.com/user-attachments/assets/a0eb5123-a3ea-4dad-aa38-f5a1f5c2d3a9)


